### PR TITLE
Don't override environment variables with env file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,7 @@ go 1.16
 require (
 	github.com/alecthomas/kong v0.2.16
 	github.com/joho/godotenv v1.3.0
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/stretchr/testify v1.7.0
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,9 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -15,5 +16,6 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/resolver.go
+++ b/resolver.go
@@ -2,6 +2,7 @@ package kongdotenv
 
 import (
 	"io"
+	"os"
 
 	"github.com/alecthomas/kong"
 	"github.com/joho/godotenv"
@@ -17,6 +18,12 @@ func ENVFile(r io.Reader) (kong.Resolver, error) {
 	}
 
 	var f kong.ResolverFunc = func(context *kong.Context, parent *kong.Path, flag *kong.Flag) (interface{}, error) {
+		if flag.Env == "" {
+			return nil, nil
+		} else if _, ok := os.LookupEnv(flag.Env); ok {
+			return nil, nil
+		}
+
 		raw, ok := values[flag.Env]
 		if !ok {
 			return nil, nil

--- a/resolver.go
+++ b/resolver.go
@@ -2,7 +2,6 @@ package kongdotenv
 
 import (
 	"io"
-	"os"
 
 	"github.com/alecthomas/kong"
 	"github.com/joho/godotenv"
@@ -18,9 +17,7 @@ func ENVFile(r io.Reader) (kong.Resolver, error) {
 	}
 
 	var f kong.ResolverFunc = func(context *kong.Context, parent *kong.Path, flag *kong.Flag) (interface{}, error) {
-		if flag.Env == "" {
-			return nil, nil
-		} else if _, ok := os.LookupEnv(flag.Env); ok {
+		if flag.Value != nil || flag.Env == "" {
 			return nil, nil
 		}
 

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -58,13 +58,31 @@ STRING_2=$STRING
 	require.True(t, cli.Bool)
 }
 
-func TestPrioritizeEnvOverEnv(t *testing.T) {
+func TestPrioritizeEnvVarOverEnvFile(t *testing.T) {
 	defer os.Clearenv()
 
 	require.NoError(t, os.Setenv("STRING", "pizza"))
 
 	var cli struct {
 		String string `env:"STRING"`
+	}
+
+	envFile := `STRING=🍕`
+
+	r, err := kong_dotenv.ENVFile(strings.NewReader(envFile))
+	require.NoError(t, err)
+
+	parser := mustNew(t, &cli, kong.Resolvers(r))
+	_, err = parser.Parse([]string{})
+	require.NoError(t, err)
+	require.Equal(t, "pizza", cli.String)
+}
+
+func TestPrioritizeDefaultOverEnvFile(t *testing.T) {
+	require.NoError(t, os.Setenv("STRING", "pizza"))
+
+	var cli struct {
+		String string `kong:"env:STRING,default=pizza"`
 	}
 
 	envFile := `STRING=🍕`

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -1,14 +1,13 @@
 package kongdotenv_test
 
 import (
+	"os"
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/alecthomas/kong"
-
 	kong_dotenv "github.com/bluegosolutions/kong-dotenv-go"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseENVFileBasic(t *testing.T) {
@@ -18,12 +17,12 @@ func TestParseENVFileBasic(t *testing.T) {
 		Bool   bool   `env:"BOOL"`
 	}
 
-	envFlie := `STRING=🍕
+	envFile := `STRING=🍕
 INT=5
 BOOL=true
 `
 
-	r, err := kong_dotenv.ENVFile(strings.NewReader(envFlie))
+	r, err := kong_dotenv.ENVFile(strings.NewReader(envFile))
 	require.NoError(t, err)
 
 	parser := mustNew(t, &cli, kong.Resolvers(r))
@@ -42,13 +41,13 @@ func TestParseENVFileSubstitutions(t *testing.T) {
 		String2 string `env:"STRING_2"`
 	}
 
-	envFlie := `STRING=🍕
+	envFile := `STRING=🍕
 INT=5
 BOOL=true
 STRING_2=$STRING
 `
 
-	r, err := kong_dotenv.ENVFile(strings.NewReader(envFlie))
+	r, err := kong_dotenv.ENVFile(strings.NewReader(envFile))
 	require.NoError(t, err)
 
 	parser := mustNew(t, &cli, kong.Resolvers(r))
@@ -57,6 +56,26 @@ STRING_2=$STRING
 	require.Equal(t, "🍕", cli.String)
 	require.Equal(t, 5, cli.Int)
 	require.True(t, cli.Bool)
+}
+
+func TestPrioritizeEnvOverEnv(t *testing.T) {
+	defer os.Clearenv()
+
+	require.NoError(t, os.Setenv("STRING", "pizza"))
+
+	var cli struct {
+		String string `env:"STRING"`
+	}
+
+	envFile := `STRING=🍕`
+
+	r, err := kong_dotenv.ENVFile(strings.NewReader(envFile))
+	require.NoError(t, err)
+
+	parser := mustNew(t, &cli, kong.Resolvers(r))
+	_, err = parser.Parse([]string{})
+	require.NoError(t, err)
+	require.Equal(t, "pizza", cli.String)
 }
 
 func mustNew(t *testing.T, cli interface{}, options ...kong.Option) *kong.Kong {


### PR DESCRIPTION
Environment variables should be chosen over values from `.env` files.
Currently, Kong reads the environment variable, but then the `dotenv` resolver overrides it.
This behaviour is unusual - most software prioritizes real environment variables over `.env` files.
This PR fixes this behaviour.